### PR TITLE
Ci use short sha

### DIFF
--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -30,7 +30,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: devopsoh/api-poi
         registry: openhackt7t44282acr.azurecr.io
-        tag_with_sha: true 
+        tags: ${{ github.sha }} 
         path: apis/poi/web/
         
     
@@ -50,6 +50,6 @@ jobs:
     - uses: azure/webapps-deploy@v2
       with:
         app-name: 'openhackt7t44282poi'
-        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${{github.sha::8}}'
+        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:${{ github.sha }}'
         
         

--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -34,7 +34,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: devopsoh/api-poi
         registry: openhackt7t44282acr.azurecr.io
-        tags: $SHA8 
+        tag_with_sha: true 
         path: apis/poi/web/
         
     
@@ -54,6 +54,6 @@ jobs:
     - uses: azure/webapps-deploy@v2
       with:
         app-name: 'openhackt7t44282poi'
-        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:$SHA8'
+        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-$SHA8'
         
         

--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -36,7 +36,6 @@ jobs:
         registry: openhackt7t44282acr.azurecr.io
         tags: $SHA8 
         path: apis/poi/web/
-        tags: latest 
         
     
     - name: ACR authentication

--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -54,6 +54,6 @@ jobs:
     - uses: azure/webapps-deploy@v2
       with:
         app-name: 'openhackt7t44282poi'
-        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-$SHA8'
+        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${SHA8}'
         
         

--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -54,6 +54,6 @@ jobs:
     - uses: azure/webapps-deploy@v2
       with:
         app-name: 'openhackt7t44282poi'
-        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${SHA8}'
+        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${{SHA8}}'
         
         

--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -17,6 +17,10 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    #Set env variables to use on builds:
+    env:
+      SHA8: ${GITHUB_SHA::8}
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
   # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -30,7 +34,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: devopsoh/api-poi
         registry: openhackt7t44282acr.azurecr.io
-        tag_with_sha: true 
+        tags: $SHA8 
         path: apis/poi/web/
         tags: latest 
         
@@ -51,6 +55,6 @@ jobs:
     - uses: azure/webapps-deploy@v2
       with:
         app-name: 'openhackt7t44282poi'
-        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:latest'
+        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:$SHA8'
         
         

--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -17,10 +17,6 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    #Set env variables to use on builds:
-    env:
-      SHA8: ${GITHUB_SHA::8}
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
   # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -54,6 +50,6 @@ jobs:
     - uses: azure/webapps-deploy@v2
       with:
         app-name: 'openhackt7t44282poi'
-        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${{SHA8}}'
+        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${{GITHUB_SHA::8}}'
         
         

--- a/.github/workflows/api-poi-cd.yml
+++ b/.github/workflows/api-poi-cd.yml
@@ -50,6 +50,6 @@ jobs:
     - uses: azure/webapps-deploy@v2
       with:
         app-name: 'openhackt7t44282poi'
-        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${{GITHUB_SHA::8}}'
+        images: 'openhackt7t44282acr.azurecr.io/devopsoh/api-poi:sha-${{github.sha::8}}'
         
         


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Closes #33 
Forced to use complete SHA instead of just 8 characters, could not parse the shortened tag in the webapps-deploy action